### PR TITLE
mpi detecting build and run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ More tips and advice on performance tuning:
 https://developer.nvidia.com/blog/creating-faster-molecular-dynamics-simulations-with-gromacs-2020/
 https://manual.gromacs.org/current/user-guide/mdrun-performance.html#running-mdrun-within-a-single-node
 
+EDIT 1

--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ https://developer.nvidia.com/blog/creating-faster-molecular-dynamics-simulations
 https://manual.gromacs.org/current/user-guide/mdrun-performance.html#running-mdrun-within-a-single-node
 
 EDIT 1
+
+EDIT 2

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -106,3 +106,5 @@ fi
 if [[ $run_type == "tmpi_init" ]]; then
     run_tmpi_init
 fi
+
+# EDIT 3


### PR DESCRIPTION
Uses readlink -f to search for a default /opt/ompi if --with-mpi is not passed.

checks for dir prior to running